### PR TITLE
feat: new function to define border color in empty highlighted star

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Ratingbar composable can be customized using  [RatingBarConfig](https://github.c
                 .activeColor(Color.Yellow)
                 .hideInactiveStars(true)
                 .inactiveColor(Color.LightGray)
+                .inactiveBorderColor(Color.Blue)
                 .stepSize(StepSize.HALF)
                 .numStars(10)
                 .isIndicator(true)

--- a/ratingbar/src/main/java/com/gowtham/ratingbar/RatingBarConfig.kt
+++ b/ratingbar/src/main/java/com/gowtham/ratingbar/RatingBarConfig.kt
@@ -70,6 +70,12 @@ class RatingBarConfig {
         private set
 
     /**
+     * A border [Color] shown on inactive star.
+     */
+    var inactiveBorderColor: Color = Color(0xFF888888)
+        private set
+
+    /**
      * Minimum value to trigger a change
      */
     var stepSize: StepSize = StepSize.ONE
@@ -143,6 +149,15 @@ class RatingBarConfig {
     fun inactiveColor(value: Color): RatingBarConfig =
         apply {
             inactiveColor = value
+        }
+
+    /**
+     * Sets the [Color] representing a inactive star (or part of it).
+     * @param value the value in [Color]
+     */
+    fun inactiveBorderColor(value: Color): RatingBarConfig =
+        apply {
+            inactiveBorderColor = value
         }
 
     /**

--- a/ratingbar/src/main/java/com/gowtham/ratingbar/RatingStar.kt
+++ b/ratingbar/src/main/java/com/gowtham/ratingbar/RatingStar.kt
@@ -70,7 +70,7 @@ private fun EmptyStar(
         if (config.style is RatingBarStyle.Normal)
             drawPath(path, color = config.inactiveColor, style = Fill) // Border
         else
-            drawPath(path, color = Color.Gray, style = Stroke(width = strokeWidth)) // Border
+            drawPath(path, color = config.inactiveBorderColor, style = Stroke(width = strokeWidth)) // Border
     }
 
 @Preview(showBackground = true)
@@ -80,8 +80,21 @@ fun EmptyRatingStarPreview() {
         fraction = 0f,
         config = RatingBarConfig()
             .activeColor(Color(0xffffd740))
-            .inactiveColor(Color(0xffffd740))
+            .inactiveColor(Color.Gray)
             .style(RatingBarStyle.Normal),
+        modifier = Modifier.size(20.dp)
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun HighlightedWithBorderColorPreview() {
+    RatingStar(
+        fraction = 0.5f,
+        config = RatingBarConfig()
+            .activeColor(Color(0xffffd740))
+            .inactiveBorderColor(Color.Blue)
+            .style(RatingBarStyle.HighLighted),
         modifier = Modifier.size(20.dp)
     )
 }


### PR DESCRIPTION
First of all: thank you for your lib, it is amazing! I want to contribute, so... here is my first contrib: Make possible to customize empty star border.

Sample:

```kotlin
RatingBar(
    value = 3.2f,
    config = RatingBarConfig()
        .inactiveBorderColor(Color.Blue)
        .style(RatingBarStyle.HighLighted)
)
```

![Screenshot_1649728753](https://user-images.githubusercontent.com/5183768/162872995-48f46694-c720-4605-b6b3-e26cd59bd2f9.png)

If you have ideas, let me known! Thank you.
